### PR TITLE
Printer example now injects a passthrough filter.

### DIFF
--- a/examples/install_printers.py
+++ b/examples/install_printers.py
@@ -96,7 +96,7 @@ for printer in printers:
 		f_ppd = open(os.path.join('/etc/cups/ppd', printer['name'] + '.ppd'), 'r+')
 		ppd = f_ppd.read()
 		for o,n in printer['editppd'].iteritems():
-			newppd = re.sub(o,n, ppd)
+			ppd = re.sub(o,n, ppd)
 		f_ppd.seek(0)
 		f_ppd.write(ppd)
 		f_ppd.close()

--- a/examples/install_printers_config.py
+++ b/examples/install_printers_config.py
@@ -1,4 +1,5 @@
 import platform
+import os
 
 darwin = int(platform.release().split('.')[0])
 
@@ -36,13 +37,22 @@ printers.append({
 		'SelectColor-default' : 'Grayscale',
 		'Duplex-default' : 'DuplexNoTumble',
 	},
-#	'editppd' : {
+	'editppd' : {
 #		'^\*DefaultKMDuplex: .*$' : '*DefaultKMDuplex: Double',
 #		'^\*DefaultSelectColor: .*$' : '*DefaultSelectColor: Grayscale',
-#	},
+	},
 	'remote' : True,
     'download' : 'https://robert.physcip.uni-stuttgart.de:631/printers/nymeria_physcip_uni_stuttgart_de.ppd',
 })
+
+# Insert a passthrough filter to change the MIME type to application/postscript. That way, the remote CUPS server runs the job through pstops again and counts the pages.
+printers[-1]['editppd'][r'(\\*APPrinterIconPath: .*)'] = r'\1\n*cupsFilter2: "application/vnd.cups-postscript application/postscript 0 passthru"'
+filter = '/usr/libexec/cups/filter/passthru'
+pt = open(filter, 'w')
+pt.write('#!/bin/bash\n\n/bin/cat -')
+pt.close()
+os.chmod(filter, 0755)
+
 # if darwin == 10:
 #     printers[-1]['download'] = 'https://o.cses.konicaminolta.com/file/Default.aspx?FilePath=DL/201307/25042126/BHC554ePSMacOS106_302MU.dmg'
 #     printers[-1]['version'] = '3.0.2'


### PR DESCRIPTION
This is necessary to change the MIME type to application/postscript. If we don't do this, the remote CUPS server does not run through pstops again and does not count the pages printed.
