### PR TITLE
Added script for creating ProductMetadata.plist

### DIFF
--- a/predicate_installer.py
+++ b/predicate_installer.py
@@ -6,6 +6,7 @@ import time
 import os
 import sys
 import platform
+import subprocess
 from threading import Thread
 from PyObjCTools import AppHelper
 

--- a/predicate_installer.py
+++ b/predicate_installer.py
@@ -9,6 +9,8 @@ import platform
 from threading import Thread
 from PyObjCTools import AppHelper
 
+metaFile = "/Library/Updates/ProductMetadata.plist"
+
 if (not os.path.isfile(metaFile) or os.path.getsize(metaFile) < 2**20): #1KB
 	subprocess.check_call(['/usr/sbin/softwareupdate', "--list"])
 

--- a/predicate_installer.py
+++ b/predicate_installer.py
@@ -9,6 +9,9 @@ import platform
 from threading import Thread
 from PyObjCTools import AppHelper
 
+if (not os.path.isfile(metaFile) or os.path.getsize(metaFile) < 2**20): #1KB
+	subprocess.check_call(['/usr/sbin/softwareupdate', "--list"])
+
 finishedInstall = False
 
 def installlog():

--- a/predicate_installer.py
+++ b/predicate_installer.py
@@ -12,7 +12,7 @@ from PyObjCTools import AppHelper
 
 metaFile = "/Library/Updates/ProductMetadata.plist"
 
-if (not os.path.isfile(metaFile) or os.path.getsize(metaFile) < 2**20): #1KB
+if (not os.path.isfile(metaFile) or os.path.getsize(metaFile) < 2**10): #1KB
 	subprocess.check_call(['/usr/sbin/softwareupdate', "--list"])
 
 finishedInstall = False


### PR DESCRIPTION
Hi mkuron,

I work at a print-management company and we have found your code very useful. I couldn't find any license terms, but I hope you are fine with us using it.

I ran into a few problems, when the /Library/Updates/ProductMetadata.plist was empty or non-existing. Therefore, I extended your script a bit to create a new cache. It's tested for printers and works so far without any hiccups. It will most likely also work for other updates.
